### PR TITLE
feat: add pending bond ui

### DIFF
--- a/src/components/keeper/keeper.jsx
+++ b/src/components/keeper/keeper.jsx
@@ -334,6 +334,10 @@ class Keeper extends Component {
               <Typography variant='h4' className={ classes.valueTitle }>Work Completed</Typography>
               <Typography variant='h3' className={ classes.valueValue }>{ keeperAsset.workCompleted }</Typography>
             </div>
+            <div className={ classes.valueContainer }>
+              <Typography variant='h4' className={ classes.valueTitle }>Bonds pending activation</Typography>
+              { this.renderPendingBonds() }
+            </div>
             {
               this.renderStatus()
             }
@@ -461,6 +465,19 @@ class Keeper extends Component {
         >
           add
         </Button>
+      </div>
+    )
+  }
+
+  renderPendingBonds = () => {
+    const { classes } = this.props
+    const {
+      keeperAsset,
+    } = this.state
+
+    return (
+      <div className={ classes.valueAction }>
+        <Typography variant='h3' className={ classes.valueValue }> { keeperAsset.pendingBonds ? keeperAsset.pendingBonds.toFixed(2) : '0.00' } { keeperAsset.symbol } </Typography>
       </div>
     )
   }


### PR DESCRIPTION
Add pending bonds to UI since quite a few people across Discord and Medium are thinking that their bonds disappeared because they did not read any of the documentation and didn't see that bonds have a 3 day vesting period.

This should help make it more clear that they didn't lose their bond and it is just pending activation.

Here is a screenshot for my test (note, the extra decimal points  are there for testing purposes since I don't have much KPR. This commit keeps the toFixed(2) that is used elsewhere.)
![image](https://user-images.githubusercontent.com/7820952/97487778-8b30b000-191a-11eb-8597-0feb0c3b7e1d.png)
