### PR TITLE
fix activate button logic

### DIFF
--- a/src/components/keeper/keeper.jsx
+++ b/src/components/keeper/keeper.jsx
@@ -475,11 +475,10 @@ class Keeper extends Component {
 
     let state = 'Inactive'
 
-    if(parseInt(keeperAsset.bondings) > 0 && moment(keeperAsset.bondings*1000).valueOf() >= moment().valueOf()) {
-      state = 'Activating'
-    }
     if(keeperAsset.isActive) {
       state = 'Active'
+    } else if (parseInt(keeperAsset.bondings) > 0) {
+      state = 'Activating'
     }
 
     if(state === 'Inactive') {
@@ -584,7 +583,7 @@ class Keeper extends Component {
       keeperAsset,
     } = this.state
 
-    if(parseInt(keeperAsset.bondings) > 0 && moment(keeperAsset.bondings*1000).valueOf() >= moment().valueOf()) {
+    if(parseInt(keeperAsset.pendingBonds) > 0) {
       return (
         <div className={ classes.valueContainer }>
           <Typography variant='h4' className={ classes.valueTitle }>Bonds pending activation</Typography>


### PR DESCRIPTION
The activate button currently doesn't show up if bondings > than the current time.

This is because the Activating state is set if the bondings timestamp is > than current time
![image](https://user-images.githubusercontent.com/7820952/97786230-87de3400-1b67-11eb-88c6-2312cec7c15e.png)

But, the activate button is only rendered if the state is Activating and the bondings timestamp is <= than the current time:
![image](https://user-images.githubusercontent.com/7820952/97786248-9fb5b800-1b67-11eb-9c7b-b9cd54232eb3.png)

This is currently impossible, so I switched the Activatable state to be enabled when bondings is greater than 0, which will allow either the "activate button" to render or the "Activatable At" UI to render.

I also switched pendingBonds to still render if they haven't been activated yet. I think that is nicer, because it shows the user how many pending bonds they can activate when they hit the button:
![image](https://user-images.githubusercontent.com/7820952/97786306-e0adcc80-1b67-11eb-970a-ab56f0dffb1f.png)
