### PR TITLE
hide activate bonds button if there are no pending bonds that are activatable

### DIFF
--- a/src/components/keeper/keeper.jsx
+++ b/src/components/keeper/keeper.jsx
@@ -521,7 +521,7 @@ class Keeper extends Component {
               <Typography variant='h3' className={ classes.valueValue }> { moment(keeperAsset.bondings*1000).format("YYYY/MM/DD kk:mm") }</Typography>
             </div>
           }
-          { parseInt(keeperAsset.bondings) > 0 && moment(keeperAsset.bondings*1000).valueOf() < moment().valueOf() &&
+          { parseInt(keeperAsset.bondings) > 0 && moment(keeperAsset.bondings*1000).valueOf() < moment().valueOf() && keeperAsset.pendingBonds > 0 &&
             <div className={ classes.valueContainer }>
               <Typography variant='h4' className={ classes.valueTitle }>Activate</Typography>
               <Button


### PR DESCRIPTION
Addresses #5 by not showing Activate Bonds if there are no pending bonds and the Keeper is active

Current UI with active keeper, no pending bonds activatable (Activate Bonds is showing, but shouldn't):
![image](https://user-images.githubusercontent.com/7820952/97789616-1611e480-1b7f-11eb-936c-7b0b531a9268.png)

New changes with active keeper, no pending bonds activatable (Activate Bonds is hidden):
![image](https://user-images.githubusercontent.com/7820952/97789626-3346b300-1b7f-11eb-99dc-9bbb7d8ea685.png)

New changes with active keeper, pending bonds NOT activatable yet (Activate Bonds is hidden, but pending bonds show):
![image](https://user-images.githubusercontent.com/7820952/97789656-815bb680-1b7f-11eb-90c4-0e68e4d479f4.png)

New changes with active keeper, pending bonds activatable (Activate Bonds button shows):
![image](https://user-images.githubusercontent.com/7820952/97789712-cc75c980-1b7f-11eb-910a-92acb66fc0fe.png)
