### PR TITLE
use correct bond amount for remove suggestion

### DIFF
--- a/src/components/keeper/keeper.jsx
+++ b/src/components/keeper/keeper.jsx
@@ -664,7 +664,7 @@ class Keeper extends Component {
     return (
       <div>
         <div className={ classes.inputContainer }>
-          <Typography variant='h6' className={ classes.balance } onClick={ () => { this.maxClicked('bondRemove') } }>{ keeperAsset.balance.toFixed(4) } { keeperAsset.symbol }</Typography>
+          <Typography variant='h6' className={ classes.balance } onClick={ () => { this.maxClicked('bondRemove') } }>{ keeperAsset.bonds.toFixed(4) } { keeperAsset.symbol }</Typography>
           <TextField
             fullwidth
             disabled={ loading }

--- a/src/components/keeper/keeper.jsx
+++ b/src/components/keeper/keeper.jsx
@@ -794,7 +794,7 @@ class Keeper extends Component {
 
     let error = false
 
-    if(removeBondAmount > keeperAsset.balance) {
+    if(removeBondAmount > keeperAsset.bonds) {
       error = true
       this.setState({ removeBondAmountError: 'Amount > bonded balance' })
     }


### PR DESCRIPTION
The remove suggestion uses the current balance of K3PR and not the bonded balance. Thus users with less balance than their bonds cannot call remove because the button field will contain higher than the suggested limit.

Before:
![image](https://user-images.githubusercontent.com/7820952/97807686-0d6ced00-1c17-11eb-9fde-88c7b60e0077.png)

After:
![image](https://user-images.githubusercontent.com/7820952/97807683-02b25800-1c17-11eb-9708-25b7538e2681.png)
