### PR TITLE
Fix refresh on job page

### DIFF
--- a/src/stores/store.jsx
+++ b/src/stores/store.jsx
@@ -1863,6 +1863,7 @@ class Store {
 
     const account = store.getStore('account')
     const web3 = await this._getWeb3Provider();
+    if(web3 == null) return;
     const keeperContract = new web3.eth.Contract(KeeperABI, config.keeperAddress)
 
     let notException = true


### PR DESCRIPTION
This fixes job page so that a refresh on a direct job link doesnt fail when web3 is not available.