### PR TITLE
fix contract action function display

### DIFF
--- a/src/components/propose/contractAction.jsx
+++ b/src/components/propose/contractAction.jsx
@@ -149,7 +149,7 @@ class ContractAction extends Component {
 
   renderFunctions = (abi) => {
     const funcs = abi.filter((thing) => {
-      return thing.type === 'function' && thing.constant === false
+      return thing.type === 'function' && thing.constant !== true
     })
 
     return funcs.map((func) => {


### PR DESCRIPTION
properly filter the functions from a contract ABI when `constant` is undefined, as it usually is
![image](https://user-images.githubusercontent.com/2591290/125124509-0bfc9a00-e0ad-11eb-9503-b212131a5918.png)
